### PR TITLE
Added SMTP(S) and external cert support for listener mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ joro
 test/
 dist/
 web/node_modules/
-!web/dist/.gitkeep
 
 # plugins
 *.dylib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Three modes:
 Ports & paths:
 - Proxy `:8080` (`--proxy-port`), UI/API `:9090` (`--ui-port`)
 - Data dir `~/.joro/` — CA cert/key + `callbacks.db`
-- Listener: DNS `:53` (`--dns-port`), HTTP `:80` (`--http-port`), HTTPS `:443` (`--https-port`, `0` to disable), domain via `--domain` or UI
+- Listener: DNS `:53` (`--dns-port`), HTTP `:80` (`--http-port`), HTTPS `:443` (`--https-port`, `0` to disable), domain via `--domain` or UI, optional external TLS cert via `--tls-cert` + `--tls-key` (both required; replaces the auto-generated self-signed leaf)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ Tracked via `go.mod` / `go.sum` only — repo does **not** vendor (see "no vendo
 - **No `os.Exit` in packages.** Only `main.go` exits. Internal packages return errors.
 - **Intercept uses per-request channels.** `InterceptQueue.Pause()` blocks the proxy goroutine until `Resolve()` or timeout (default 60s). Don't change to polling.
 - **CA cert reused across restarts.** `cert.LoadOrCreate()` only regenerates when missing.
-- **`web/dist/` embedded** via `//go:embed dist`. Placeholder `index.html` exists so `go build` works before `npm run build`.
+- **`web/dist/` embedded** via `//go:embed dist`. Populated by `npm run build` before Go compiles — `make build` runs the frontend first, and the goreleaser `before:` hook does the same. Bare `go build ./...` requires `npm run build` to have run.
 - **Noise filter is separate from scope.** Silently tunnels common browser background traffic (captive portal, telemetry, OCSP, safe browsing) without capture. Enabled by default. Checked **before** scope — noisy hosts never MITM'd regardless of scope rules.
 - **Two-level scope filtering.** L1 (CONNECT): host pattern only — out-of-scope hosts tunneled raw without MITM. L2 (request): host + method + path after TLS termination — out-of-scope requests forwarded without capture/intercept. Disabled by default; enabled with no rules blocks everything (safe default). Exclude rules override include rules.
 - **Listener mode is mutually exclusive with proxy mode.** `--listener` starts DNS + HTTP callback servers + reduced API/UI. No CA, proxy, or intercept. Data in `~/.joro/callbacks.db`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,13 @@ Joro is an intercepting HTTP/HTTPS proxy and web shell toolkit for penetration t
 
 Three modes:
 - **Proxy mode** (default): intercepting proxy + web UI
-- **Listener mode** (`--listener`): out-of-band callback server (DNS + HTTP) for blind vuln detection
+- **Listener mode** (`--listener`): out-of-band callback server (DNS + HTTP + SMTP) for blind vuln detection
 - **Team Server mode** (`--listener --teamserver`): listener + authenticated team collaboration (chat, notes)
 
 Ports & paths:
 - Proxy `:8080` (`--proxy-port`), UI/API `:9090` (`--ui-port`)
 - Data dir `~/.joro/` — CA cert/key + `callbacks.db`
-- Listener: DNS `:53` (`--dns-port`), HTTP `:80` (`--http-port`), HTTPS `:443` (`--https-port`, `0` to disable), domain via `--domain` or UI, optional external TLS cert via `--tls-cert` + `--tls-key` (both required; replaces the auto-generated self-signed leaf)
+- Listener: DNS `:53` (`--dns-port`), HTTP `:80` (`--http-port`), HTTPS `:443` (`--https-port`, `0` to disable), SMTP `:25` (`--smtp-port`, `0` to disable), SMTPS `:465` (`--smtps-port`, `0` to disable), domain via `--domain` or UI, optional external TLS cert via `--tls-cert` + `--tls-key` (both required; replaces the auto-generated self-signed leaf, shared by HTTPS and SMTPS/STARTTLS)
 
 ---
 
@@ -249,7 +249,7 @@ Tracked via `go.mod` / `go.sum` only — repo does **not** vendor (see "no vendo
 - **Two-level scope filtering.** L1 (CONNECT): host pattern only — out-of-scope hosts tunneled raw without MITM. L2 (request): host + method + path after TLS termination — out-of-scope requests forwarded without capture/intercept. Disabled by default; enabled with no rules blocks everything (safe default). Exclude rules override include rules.
 - **Listener mode is mutually exclusive with proxy mode.** `--listener` starts DNS + HTTP callback servers + reduced API/UI. No CA, proxy, or intercept. Data in `~/.joro/callbacks.db`.
 - **Token entropy:** 12 hex chars = 48 bits. Correlated by leftmost subdomain label.
-- **Port 53 needs root/capabilities on Linux.** `setcap cap_net_bind_service=+ep ./joro` or iptables redirect.
+- **Privileged ports need root/capabilities on Linux.** DNS `:53`, SMTP `:25`, HTTP `:80`, HTTPS `:443`, SMTPS `:465` are all <1024. `setcap cap_net_bind_service=+ep ./joro` or iptables redirect; or use the `--{dns,http,https,smtp,smtps}-port` flags to pick unprivileged ports.
 - **`internal/event` package** holds shared `WSEvent` to avoid proxy↔callback import cycle.
 - **Match & Replace operates on raw bytes.** Splits raw dump at `\r\n\r\n`, applies header/body rules independently, then reparses. Cumulative in order. Supports `string` and `regex`. Targets: `request_header`, `request_body`, `response_header`, `response_body`, `ws_message`.
 - **WebSocket MITM uses custom frame reader/writer** on raw `net.Conn` (not gorilla). Detected via `Upgrade: websocket`. After 101, two goroutines relay bidirectionally. Control frames forwarded immediately; data frames accumulated until FIN, match/replace applied on complete messages, forwarded as single frame. 16MB payload limit.

--- a/internal/callback/smtp.go
+++ b/internal/callback/smtp.go
@@ -1,0 +1,358 @@
+package callback
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/mail"
+	"strings"
+	"time"
+
+	"github.com/BishopFox/joro/internal/event"
+)
+
+const (
+	smtpMaxLine     = 1000          // RFC 5321 §4.5.3.1.6
+	smtpMaxData     = 1 << 20       // 1 MiB cap on DATA payload
+	smtpMaxRcpts    = 5             // bound per-session memory
+	smtpIdleTimeout = 5 * time.Minute
+)
+
+// SMTPServer listens for SMTP connections and records inbound mail as
+// callback interactions. It is a capture-only server — no relay, no AUTH.
+type SMTPServer struct {
+	store         *Store
+	broadcast     chan<- any
+	bindAddr      string
+	plainPort     int
+	tlsPort       int
+	tlsCfg        *tls.Config
+	plainListener net.Listener
+	tlsListener   net.Listener
+}
+
+// NewSMTPServer creates an SMTP capture server. plainPort=0 disables the
+// plain listener; tlsPort=0 disables the implicit-TLS (SMTPS) listener.
+// tlsCfg=nil disables STARTTLS on the plain listener.
+func NewSMTPServer(store *Store, broadcast chan<- any, bindAddr string,
+	plainPort, tlsPort int, tlsCfg *tls.Config) *SMTPServer {
+	return &SMTPServer{
+		store:     store,
+		broadcast: broadcast,
+		bindAddr:  bindAddr,
+		plainPort: plainPort,
+		tlsPort:   tlsPort,
+		tlsCfg:    tlsCfg,
+	}
+}
+
+// Start opens the configured listeners and accepts connections until ctx
+// is cancelled.
+func (s *SMTPServer) Start(ctx context.Context) error {
+	errCh := make(chan error, 2)
+
+	if s.plainPort > 0 {
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.bindAddr, s.plainPort))
+		if err != nil {
+			return fmt.Errorf("smtp plain listen: %w", err)
+		}
+		s.plainListener = ln
+		go s.acceptLoop(ln, false, errCh)
+	}
+
+	if s.tlsPort > 0 {
+		if s.tlsCfg == nil {
+			return fmt.Errorf("smtps requires a TLS config")
+		}
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.bindAddr, s.tlsPort))
+		if err != nil {
+			return fmt.Errorf("smtps listen: %w", err)
+		}
+		s.tlsListener = ln
+		go s.acceptLoop(ln, true, errCh)
+	}
+
+	go func() {
+		<-ctx.Done()
+		if s.plainListener != nil {
+			s.plainListener.Close() //nolint:errcheck
+		}
+		if s.tlsListener != nil {
+			s.tlsListener.Close() //nolint:errcheck
+		}
+	}()
+
+	return <-errCh
+}
+
+func (s *SMTPServer) acceptLoop(ln net.Listener, implicitTLS bool, errCh chan<- error) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		go s.handleConnection(conn, implicitTLS)
+	}
+}
+
+// smtpSession holds per-connection state. STARTTLS resets all fields except
+// the underlying conn (which gets wrapped).
+type smtpSession struct {
+	from       string
+	rcpts      []string
+	transcript bytes.Buffer
+	isTLS      bool
+}
+
+func (s *SMTPServer) handleConnection(conn net.Conn, implicitTLS bool) {
+	defer conn.Close() //nolint:errcheck
+
+	if implicitTLS {
+		tlsConn := tls.Server(conn, s.tlsCfg)
+		if err := tlsConn.SetDeadline(time.Now().Add(smtpIdleTimeout)); err == nil {
+			if err := tlsConn.Handshake(); err != nil {
+				return
+			}
+		}
+		conn = tlsConn
+	}
+
+	sess := &smtpSession{isTLS: implicitTLS}
+	rw := bufio.NewReadWriter(bufio.NewReaderSize(conn, smtpMaxLine+2), bufio.NewWriter(conn))
+
+	s.writeLine(rw, sess, "220 joro ESMTP ready")
+
+	for {
+		conn.SetReadDeadline(time.Now().Add(smtpIdleTimeout)) //nolint:errcheck
+		line, err := s.readLine(rw)
+		if err != nil {
+			return
+		}
+		sess.transcript.WriteString("C: ")
+		sess.transcript.WriteString(line)
+		sess.transcript.WriteString("\r\n")
+
+		verb, rest := splitVerb(line)
+		switch strings.ToUpper(verb) {
+		case "HELO":
+			sess.from, sess.rcpts = "", nil
+			s.writeLine(rw, sess, "250 joro")
+		case "EHLO":
+			sess.from, sess.rcpts = "", nil
+			lines := []string{"250-joro", fmt.Sprintf("250-SIZE %d", smtpMaxData)}
+			if s.tlsCfg != nil && !sess.isTLS {
+				lines = append(lines, "250-STARTTLS")
+			}
+			lines = append(lines, "250 HELP")
+			s.writeLines(rw, sess, lines)
+		case "STARTTLS":
+			if s.tlsCfg == nil || sess.isTLS {
+				s.writeLine(rw, sess, "502 STARTTLS not available")
+				continue
+			}
+			s.writeLine(rw, sess, "220 Ready to start TLS")
+			rw.Flush() //nolint:errcheck
+			tlsConn := tls.Server(conn, s.tlsCfg)
+			if err := tlsConn.SetDeadline(time.Now().Add(smtpIdleTimeout)); err != nil {
+				return
+			}
+			if err := tlsConn.Handshake(); err != nil {
+				return
+			}
+			conn = tlsConn
+			rw = bufio.NewReadWriter(bufio.NewReaderSize(conn, smtpMaxLine+2), bufio.NewWriter(conn))
+			sess = &smtpSession{isTLS: true}
+		case "MAIL":
+			sess.from = parseAddrParam(rest, "FROM")
+			sess.rcpts = nil
+			s.writeLine(rw, sess, "250 OK")
+		case "RCPT":
+			addr := parseAddrParam(rest, "TO")
+			if addr != "" && len(sess.rcpts) < smtpMaxRcpts {
+				sess.rcpts = append(sess.rcpts, addr)
+			}
+			s.writeLine(rw, sess, "250 OK")
+		case "DATA":
+			if len(sess.rcpts) == 0 {
+				s.writeLine(rw, sess, "503 Need RCPT before DATA")
+				continue
+			}
+			s.writeLine(rw, sess, "354 End data with <CR><LF>.<CR><LF>")
+			data, err := s.readData(rw, sess)
+			if err != nil {
+				return
+			}
+			s.recordMessage(conn, sess, data)
+			s.writeLine(rw, sess, "250 OK queued")
+			sess.from, sess.rcpts = "", nil
+		case "RSET":
+			sess.from, sess.rcpts = "", nil
+			s.writeLine(rw, sess, "250 OK")
+		case "NOOP":
+			s.writeLine(rw, sess, "250 OK")
+		case "QUIT":
+			s.writeLine(rw, sess, "221 Bye")
+			return
+		case "VRFY", "EXPN":
+			s.writeLine(rw, sess, "252 Cannot VRFY user, but will accept message")
+		default:
+			s.writeLine(rw, sess, "502 Command not implemented")
+		}
+	}
+}
+
+func (s *SMTPServer) readLine(rw *bufio.ReadWriter) (string, error) {
+	line, err := rw.Reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	if len(line) > smtpMaxLine {
+		return "", io.ErrShortBuffer
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func (s *SMTPServer) readData(rw *bufio.ReadWriter, sess *smtpSession) ([]byte, error) {
+	var buf bytes.Buffer
+	for {
+		line, err := rw.Reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		sess.transcript.WriteString("C: ")
+		sess.transcript.WriteString(trimmed)
+		sess.transcript.WriteString("\r\n")
+		if trimmed == "." {
+			break
+		}
+		trimmed = strings.TrimPrefix(trimmed, ".")
+		if buf.Len()+len(trimmed)+2 > smtpMaxData {
+			// Drain remaining DATA but cap stored payload.
+			continue
+		}
+		buf.WriteString(trimmed)
+		buf.WriteString("\r\n")
+	}
+	return buf.Bytes(), nil
+}
+
+func (s *SMTPServer) writeLine(rw *bufio.ReadWriter, sess *smtpSession, line string) {
+	sess.transcript.WriteString("S: ")
+	sess.transcript.WriteString(line)
+	sess.transcript.WriteString("\r\n")
+	rw.WriteString(line + "\r\n") //nolint:errcheck
+	rw.Flush()                    //nolint:errcheck
+}
+
+func (s *SMTPServer) writeLines(rw *bufio.ReadWriter, sess *smtpSession, lines []string) {
+	for _, l := range lines {
+		sess.transcript.WriteString("S: ")
+		sess.transcript.WriteString(l)
+		sess.transcript.WriteString("\r\n")
+		rw.WriteString(l + "\r\n") //nolint:errcheck
+	}
+	rw.Flush() //nolint:errcheck
+}
+
+func (s *SMTPServer) recordMessage(conn net.Conn, sess *smtpSession, data []byte) {
+	cfg, _ := s.store.GetConfig()
+	domain := cfg.Domain
+
+	var token *Token
+	var matchedRcpt string
+	for _, rcpt := range sess.rcpts {
+		if tok, err := CorrelateSMTP(s.store, rcpt, domain); err == nil {
+			token = tok
+			matchedRcpt = rcpt
+			break
+		}
+	}
+	if token == nil {
+		return
+	}
+
+	var hdrFrom, hdrTo, hdrSubject, body string
+	if msg, err := mail.ReadMessage(bytes.NewReader(data)); err == nil {
+		hdrFrom = msg.Header.Get("From")
+		hdrTo = msg.Header.Get("To")
+		hdrSubject = msg.Header.Get("Subject")
+		if bodyBytes, err := io.ReadAll(msg.Body); err == nil {
+			body = string(bodyBytes)
+		}
+	}
+	if body == "" {
+		body = string(data)
+	}
+
+	headers, _ := json.Marshal(map[string]string{
+		"from":          hdrFrom,
+		"to":            hdrTo,
+		"subject":       hdrSubject,
+		"envelope_from": sess.from,
+		"envelope_to":   strings.Join(sess.rcpts, ", "),
+		"matched_rcpt":  matchedRcpt,
+		"tls":           fmt.Sprintf("%t", sess.isTLS),
+	})
+
+	sourceIP, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+	id := make([]byte, 16)
+	rand.Read(id) //nolint:errcheck
+
+	interaction := &Interaction{
+		ID:         hex.EncodeToString(id),
+		TokenID:    token.ID,
+		Token:      token.Token,
+		Type:       "smtp",
+		SourceIP:   sourceIP,
+		Timestamp:  time.Now().UTC(),
+		Headers:    string(headers),
+		Body:       base64.StdEncoding.EncodeToString([]byte(body)),
+		RawRequest: base64.StdEncoding.EncodeToString(sess.transcript.Bytes()),
+	}
+	if err := s.store.RecordInteraction(interaction); err != nil {
+		log.Printf("callback smtp: record interaction: %v", err)
+		return
+	}
+	s.broadcast <- event.WSEvent{Type: "callback.interaction", Data: interaction}
+}
+
+// splitVerb returns the first whitespace-delimited token and the remainder.
+func splitVerb(line string) (verb, rest string) {
+	line = strings.TrimSpace(line)
+	if i := strings.IndexAny(line, " \t"); i >= 0 {
+		return line[:i], strings.TrimSpace(line[i+1:])
+	}
+	return line, ""
+}
+
+// parseAddrParam extracts the address from "MAIL FROM:<addr>" / "RCPT TO:<addr>"
+// arguments. Param is "FROM" or "TO" (case-insensitive). Returns the address
+// without surrounding angle brackets; ignores trailing SIZE= and other params.
+func parseAddrParam(rest, param string) string {
+	rest = strings.TrimSpace(rest)
+	upper := strings.ToUpper(rest)
+	prefix := param + ":"
+	if !strings.HasPrefix(upper, prefix) {
+		return ""
+	}
+	rest = strings.TrimSpace(rest[len(prefix):])
+	end := len(rest)
+	if i := strings.Index(rest, " "); i >= 0 {
+		end = i
+	}
+	addr := strings.TrimSpace(rest[:end])
+	addr = strings.TrimPrefix(addr, "<")
+	addr = strings.TrimSuffix(addr, ">")
+	return addr
+}

--- a/internal/callback/token.go
+++ b/internal/callback/token.go
@@ -48,3 +48,32 @@ func Correlate(store *Store, hostname, domain string) (*Token, error) {
 
 	return store.FindTokenByHex(tokenHex)
 }
+
+// CorrelateSMTP extracts a token from an SMTP recipient address. It first
+// tries the local-part (token@anything), then falls back to subdomain-style
+// correlation on the domain part (anything@token.callback-domain).
+func CorrelateSMTP(store *Store, rcpt, callbackDomain string) (*Token, error) {
+	rcpt = strings.TrimSpace(rcpt)
+	rcpt = strings.TrimPrefix(rcpt, "<")
+	rcpt = strings.TrimSuffix(rcpt, ">")
+
+	at := strings.LastIndex(rcpt, "@")
+	if at < 0 {
+		return nil, sql.ErrNoRows
+	}
+	local, domain := rcpt[:at], rcpt[at+1:]
+
+	if len(local) >= 16 {
+		tokenHex := strings.ToLower(local[:16])
+		if _, err := hex.DecodeString(tokenHex); err == nil {
+			if tok, err := store.FindTokenByHex(tokenHex); err == nil {
+				return tok, nil
+			}
+		}
+	}
+
+	if callbackDomain != "" {
+		return Correlate(store, domain, callbackDomain)
+	}
+	return nil, sql.ErrNoRows
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	CallbackHTTPSPort  int
 	CallbackDomain      string
 	CallbackResponseIP  string
+	TLSCertFile         string
+	TLSKeyFile          string
 	TeamServer          bool
 	DisableUpdateChecks bool
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	CallbackDNSPort    int
 	CallbackHTTPPort   int
 	CallbackHTTPSPort  int
+	CallbackSMTPPort   int
+	CallbackSMTPSPort  int
 	CallbackDomain      string
 	CallbackResponseIP  string
 	TLSCertFile         string
@@ -37,5 +39,7 @@ func Default() Config {
 		CallbackDNSPort:   53,
 		CallbackHTTPPort:  80,
 		CallbackHTTPSPort: 443,
+		CallbackSMTPPort:  25,
+		CallbackSMTPSPort: 465,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -45,8 +45,10 @@ func main() {
 	flag.IntVar(&cfg.CallbackDNSPort, "dns-port", cfg.CallbackDNSPort, "DNS listener port (listener mode)")
 	flag.IntVar(&cfg.CallbackHTTPPort, "http-port", cfg.CallbackHTTPPort, "HTTP callback listener port (listener mode)")
 	flag.IntVar(&cfg.CallbackHTTPSPort, "https-port", cfg.CallbackHTTPSPort, "HTTPS callback listener port (listener mode, 0 to disable)")
-	flag.StringVar(&cfg.TLSCertFile, "tls-cert", cfg.TLSCertFile, "Path to PEM-encoded TLS certificate for HTTPS callback listener (listener mode). If set, replaces the auto-generated self-signed cert. Must be set together with --tls-key.")
-	flag.StringVar(&cfg.TLSKeyFile, "tls-key", cfg.TLSKeyFile, "Path to PEM-encoded TLS private key for HTTPS callback listener (listener mode). Must be set together with --tls-cert.")
+	flag.IntVar(&cfg.CallbackSMTPPort, "smtp-port", cfg.CallbackSMTPPort, "SMTP callback listener port (listener mode, 0 to disable)")
+	flag.IntVar(&cfg.CallbackSMTPSPort, "smtps-port", cfg.CallbackSMTPSPort, "SMTPS (implicit TLS) callback listener port (listener mode, 0 to disable)")
+	flag.StringVar(&cfg.TLSCertFile, "tls-cert", cfg.TLSCertFile, "Path to PEM-encoded TLS certificate for HTTPS/SMTPS callback listeners (listener mode). If set, replaces the auto-generated self-signed cert. Must be set together with --tls-key.")
+	flag.StringVar(&cfg.TLSKeyFile, "tls-key", cfg.TLSKeyFile, "Path to PEM-encoded TLS private key for HTTPS/SMTPS callback listeners (listener mode). Must be set together with --tls-cert.")
 	flag.StringVar(&cfg.CallbackDomain, "domain", cfg.CallbackDomain, "Callback domain (listener mode)")
 	flag.StringVar(&cfg.CallbackResponseIP, "response-ip", cfg.CallbackResponseIP, "IP address returned in DNS A responses (listener mode)")
 	flag.StringVar(&cfg.BindAddr, "bind", cfg.BindAddr, "Address to bind servers to")
@@ -131,37 +133,20 @@ func runListenerMode(ctx context.Context, cfg config.Config) {
 		}
 	}()
 
+	// Build shared TLS config if any TLS-capable listener is enabled.
+	needsTLS := cfg.CallbackHTTPSPort > 0 || cfg.CallbackSMTPSPort > 0 ||
+		cfg.TLSCertFile != "" || cfg.TLSKeyFile != ""
+	var tlsCfg *tls.Config
+	if needsTLS {
+		tlsCfg = buildCallbackTLSConfig(cfg)
+	}
+	if cfg.CallbackSMTPSPort > 0 && tlsCfg == nil {
+		log.Fatalf("--smtps-port requires TLS — supply --tls-cert/--tls-key or enable --https-port")
+	}
+
 	// Start HTTP callback server.
 	httpSrv := callback.NewHTTPServer(cbStore, xssStore, hub.Broadcast(), cfg.BindAddr, cfg.CallbackHTTPPort)
-
-	// Configure HTTPS if enabled.
 	if cfg.CallbackHTTPSPort > 0 {
-		var tlsCfg *tls.Config
-		switch {
-		case cfg.TLSCertFile != "" && cfg.TLSKeyFile != "":
-			extCert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
-			if err != nil {
-				log.Fatalf("load external TLS cert: %v", err)
-			}
-			tlsCfg = &tls.Config{Certificates: []tls.Certificate{extCert}}
-			fmt.Printf("Using external TLS cert: %s\n", cfg.TLSCertFile)
-		case cfg.TLSCertFile != "" || cfg.TLSKeyFile != "":
-			log.Fatalf("--tls-cert and --tls-key must be set together")
-		default:
-			ca, err := cert.LoadOrCreate(cfg.DataDir)
-			if err != nil {
-				log.Fatalf("CA init: %v", err)
-			}
-			names := []string{"localhost"}
-			if cfg.CallbackDomain != "" {
-				names = []string{cfg.CallbackDomain, "*." + cfg.CallbackDomain}
-			}
-			leafCert, err := cert.GenerateLeafMulti(ca, names)
-			if err != nil {
-				log.Fatalf("callback TLS cert: %v", err)
-			}
-			tlsCfg = &tls.Config{Certificates: []tls.Certificate{*leafCert}}
-		}
 		httpSrv.WithTLS(tlsCfg, cfg.CallbackHTTPSPort)
 	}
 
@@ -174,6 +159,23 @@ func runListenerMode(ctx context.Context, cfg config.Config) {
 			log.Printf("HTTP(S) callback server: %v", err)
 		}
 	}()
+
+	// Start SMTP callback server.
+	if cfg.CallbackSMTPPort > 0 || cfg.CallbackSMTPSPort > 0 {
+		smtpSrv := callback.NewSMTPServer(cbStore, hub.Broadcast(), cfg.BindAddr,
+			cfg.CallbackSMTPPort, cfg.CallbackSMTPSPort, tlsCfg)
+		go func() {
+			if cfg.CallbackSMTPPort > 0 {
+				fmt.Printf("SMTP callback listener on %s:%d\n", cfg.BindAddr, cfg.CallbackSMTPPort)
+			}
+			if cfg.CallbackSMTPSPort > 0 {
+				fmt.Printf("SMTPS callback listener on %s:%d\n", cfg.BindAddr, cfg.CallbackSMTPSPort)
+			}
+			if err := smtpSrv.Start(ctx); err != nil {
+				log.Printf("SMTP server: %v", err)
+			}
+		}()
+	}
 
 	// Generate auth token for listener API access.
 	tokenBytes := make([]byte, 16)
@@ -198,6 +200,38 @@ func runListenerMode(ctx context.Context, cfg config.Config) {
 	fmt.Printf("Callback API available at http://%s:%d\n", cfg.BindAddr, cfg.UIPort)
 	if err := apiSrv.Start(ctx); err != nil {
 		log.Fatalf("API server: %v", err)
+	}
+}
+
+// buildCallbackTLSConfig returns the TLS config shared by all callback
+// listeners (HTTPS, SMTPS, STARTTLS). External cert+key via --tls-cert/--tls-key
+// takes precedence; otherwise a leaf is generated from Joro's CA.
+func buildCallbackTLSConfig(cfg config.Config) *tls.Config {
+	switch {
+	case cfg.TLSCertFile != "" && cfg.TLSKeyFile != "":
+		extCert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
+		if err != nil {
+			log.Fatalf("load external TLS cert: %v", err)
+		}
+		fmt.Printf("Using external TLS cert: %s\n", cfg.TLSCertFile)
+		return &tls.Config{Certificates: []tls.Certificate{extCert}}
+	case cfg.TLSCertFile != "" || cfg.TLSKeyFile != "":
+		log.Fatalf("--tls-cert and --tls-key must be set together")
+		return nil
+	default:
+		ca, err := cert.LoadOrCreate(cfg.DataDir)
+		if err != nil {
+			log.Fatalf("CA init: %v", err)
+		}
+		names := []string{"localhost"}
+		if cfg.CallbackDomain != "" {
+			names = []string{cfg.CallbackDomain, "*." + cfg.CallbackDomain}
+		}
+		leafCert, err := cert.GenerateLeafMulti(ca, names)
+		if err != nil {
+			log.Fatalf("callback TLS cert: %v", err)
+		}
+		return &tls.Config{Certificates: []tls.Certificate{*leafCert}}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/BishopFox/joro/internal/xsshunter"
 )
 
-var version = "v1.0.6"
+var version = "v1.1.0"
 var commit = "dev" // injected via -ldflags at build time
 
 func main() {
@@ -45,6 +45,8 @@ func main() {
 	flag.IntVar(&cfg.CallbackDNSPort, "dns-port", cfg.CallbackDNSPort, "DNS listener port (listener mode)")
 	flag.IntVar(&cfg.CallbackHTTPPort, "http-port", cfg.CallbackHTTPPort, "HTTP callback listener port (listener mode)")
 	flag.IntVar(&cfg.CallbackHTTPSPort, "https-port", cfg.CallbackHTTPSPort, "HTTPS callback listener port (listener mode, 0 to disable)")
+	flag.StringVar(&cfg.TLSCertFile, "tls-cert", cfg.TLSCertFile, "Path to PEM-encoded TLS certificate for HTTPS callback listener (listener mode). If set, replaces the auto-generated self-signed cert. Must be set together with --tls-key.")
+	flag.StringVar(&cfg.TLSKeyFile, "tls-key", cfg.TLSKeyFile, "Path to PEM-encoded TLS private key for HTTPS callback listener (listener mode). Must be set together with --tls-cert.")
 	flag.StringVar(&cfg.CallbackDomain, "domain", cfg.CallbackDomain, "Callback domain (listener mode)")
 	flag.StringVar(&cfg.CallbackResponseIP, "response-ip", cfg.CallbackResponseIP, "IP address returned in DNS A responses (listener mode)")
 	flag.StringVar(&cfg.BindAddr, "bind", cfg.BindAddr, "Address to bind servers to")
@@ -134,21 +136,33 @@ func runListenerMode(ctx context.Context, cfg config.Config) {
 
 	// Configure HTTPS if enabled.
 	if cfg.CallbackHTTPSPort > 0 {
-		ca, err := cert.LoadOrCreate(cfg.DataDir)
-		if err != nil {
-			log.Fatalf("CA init: %v", err)
+		var tlsCfg *tls.Config
+		switch {
+		case cfg.TLSCertFile != "" && cfg.TLSKeyFile != "":
+			extCert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
+			if err != nil {
+				log.Fatalf("load external TLS cert: %v", err)
+			}
+			tlsCfg = &tls.Config{Certificates: []tls.Certificate{extCert}}
+			fmt.Printf("Using external TLS cert: %s\n", cfg.TLSCertFile)
+		case cfg.TLSCertFile != "" || cfg.TLSKeyFile != "":
+			log.Fatalf("--tls-cert and --tls-key must be set together")
+		default:
+			ca, err := cert.LoadOrCreate(cfg.DataDir)
+			if err != nil {
+				log.Fatalf("CA init: %v", err)
+			}
+			names := []string{"localhost"}
+			if cfg.CallbackDomain != "" {
+				names = []string{cfg.CallbackDomain, "*." + cfg.CallbackDomain}
+			}
+			leafCert, err := cert.GenerateLeafMulti(ca, names)
+			if err != nil {
+				log.Fatalf("callback TLS cert: %v", err)
+			}
+			tlsCfg = &tls.Config{Certificates: []tls.Certificate{*leafCert}}
 		}
-		names := []string{"localhost"}
-		if cfg.CallbackDomain != "" {
-			names = []string{cfg.CallbackDomain, "*." + cfg.CallbackDomain}
-		}
-		leafCert, err := cert.GenerateLeafMulti(ca, names)
-		if err != nil {
-			log.Fatalf("callback TLS cert: %v", err)
-		}
-		httpSrv.WithTLS(&tls.Config{
-			Certificates: []tls.Certificate{*leafCert},
-		}, cfg.CallbackHTTPSPort)
+		httpSrv.WithTLS(tlsCfg, cfg.CallbackHTTPSPort)
 	}
 
 	go func() {


### PR DESCRIPTION
#### Details

- added SMTP(S) support for listener
- added --tls-cert/--tls-key flags and rewrote the HTTPS-setup block in runListenerMode
- added TLSCertFile/TLSKeyFile fields
- Updated documentation
  - added SMTP(S) ports to listener summary and setcap note
  - added mention of the new flags in the listener summary
- Updated .gitignore