### PR TITLE
Fix automation resend EOF on HTTP/2-captured requests

### DIFF
--- a/internal/httptools/proxysend.go
+++ b/internal/httptools/proxysend.go
@@ -153,7 +153,7 @@ func roundTripViaProxy(ctx context.Context, raw []byte, scheme, hostPort string,
 		conn.SetDeadline(time.Now().Add(60 * time.Second)) //nolint:errcheck
 	}
 
-	wire := raw
+	wire := normalizeHTTP11(raw)
 	if scheme == "https" {
 		tlsConn, err := connectTunnel(conn, hostPort, d.CA)
 		if err != nil {
@@ -164,7 +164,7 @@ func roundTripViaProxy(ctx context.Context, raw []byte, scheme, hostPort string,
 	} else {
 		// Plain HTTP through a proxy uses absolute-form request targets, which is
 		// what internal/proxy/handler.go's non-CONNECT path expects.
-		wire = toAbsoluteForm(raw, hostPort)
+		wire = toAbsoluteForm(wire, hostPort)
 	}
 
 	if _, err := conn.Write(wire); err != nil {

--- a/internal/httptools/rawhttp.go
+++ b/internal/httptools/rawhttp.go
@@ -115,6 +115,41 @@ func requestLine(line string) (method, target, version string, ok bool) {
 	return method, target, version, true
 }
 
+// normalizeHTTP11 rewrites a raw request's start line to end in "HTTP/1.1".
+//
+// SendViaProxy always speaks HTTP/1.1 to Joro's own proxy (ALPN is pinned —
+// see its doc comment), but a captured request's raw bytes carry whatever
+// version token it was captured under. h2_mitm.go stamps captured HTTP/2
+// traffic with the literal "HTTP/2" (h2 has no textual wire form to
+// preserve), and net/http's server-side ReadRequest rejects that token
+// outright ("malformed HTTP version"). On that parse error mitm.go's read
+// loop just returns, closing the connection with no response written — which
+// is indistinguishable, from the sending side, from the target itself having
+// gone away mid-handshake. Left unnormalized, every automation resend of an
+// HTTP/2-captured request — the common case, since Chrome negotiates h2 with
+// nearly everything — would fail this way before ever reaching the target.
+func normalizeHTTP11(raw []byte) []byte {
+	hdr, body, _ := splitRaw(raw)
+	lines := splitHeaderLines(hdr)
+	if len(lines) == 0 {
+		return raw
+	}
+	method, target, version, ok := requestLine(lines[0])
+	if !ok || version == "HTTP/1.1" {
+		return raw
+	}
+	lines[0] = method + " " + target + " HTTP/1.1"
+
+	var out bytes.Buffer
+	for _, ln := range lines {
+		out.WriteString(ln)
+		out.WriteString("\r\n")
+	}
+	out.WriteString("\r\n")
+	out.Write(body)
+	return out.Bytes()
+}
+
 // contentTypeKeyword collapses a Content-Type to a short token. The full MIME type
 // plus charset costs roughly six tokens per row and carries no information a client
 // reasons about, so tables carry the keyword instead.


### PR DESCRIPTION
## Summary
- `http_resend`/`http_batch` failed with `reading response: unexpected EOF` on any capture originally negotiated over HTTP/2, which is most Chrome traffic.
- `h2_mitm.go` synthesizes captured HTTP/2 requests with a literal `HTTP/2` request-line token (h2 has no textual wire form). `SendViaProxy` reuses that stored raw request verbatim when writing to Joro's own proxy, which it always speaks to as HTTP/1.1 (ALPN pinned). `net/http`'s `ReadRequest` rejects `HTTP/2` as a malformed version, and `mitm.go`'s read loop silently closes the connection on that parse error with no response written — indistinguishable from the target vanishing mid-request.
- Fix: `SendViaProxy` now normalizes the request line's version to `HTTP/1.1` before writing to the wire, since that's the only version it ever actually speaks.

## Test plan
- [x] `go build ./...`
- [x] Rebuilt binary, restarted local Joro instance
- [x] Reproduced the failure pre-fix: `http_resend`/`http_batch` against an HTTP/2-captured request consistently returned `unexpected EOF`
- [x] Confirmed fix: same resend now succeeds and produces a correlated history row with byte-identical body to the original capture